### PR TITLE
Added rudimentary view of cards visible to active player.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,20 @@
 import { Client } from 'boardgame.io/react';
+import { Local } from 'boardgame.io/multiplayer';
 import { TicTacToe } from './Game';
 import { TicTacToeBoard } from './Board';
 
-const App = Client({
+const TTTClient = Client({
     game: TicTacToe,
     board: TicTacToeBoard,
+    multiplayer: Local(),
 });
+
+const App = () => (
+    <div>
+        {/* <TTTClient /> */}
+        <TTTClient playerID="0" />
+        <TTTClient playerID="1" />
+    </div>
+);
 
 export default App;

--- a/src/Board.js
+++ b/src/Board.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import LjCard from './LjCard';
+import { Button } from '@react-md/button';
 
 export class TicTacToeBoard extends React.Component {
   onClick = (id) => () => {
@@ -21,8 +22,39 @@ export class TicTacToeBoard extends React.Component {
       : `Draw!`;
   }
 
-  render() {
+  get visibleCards() {
     const {ctx, G} = this.props;
+    const common = G.drawPiles.map((pile) => pile.currentLetter);
+    const otherPlayers = Object.keys(G.players)
+      .filter((key) => `${key}` !== ctx.currentPlayer)
+      .map((key) => G.players[key].letters[G.players[key].activeLetterIndex]);
+
+    return [...common, ...otherPlayers];
+  }
+
+  handleNextLetter = () => {
+    this.props.moves.nextLetter(this.props.ctx.currentPlayer);
+  }
+
+  // TODO
+  get isNextLetterDisabled() {
+    const {ctx, G} = this.props;
+    // G.players[ctx.currentPlayer].letters.length;
+    return false;
+  }
+
+  get activePlayerCards() {
+    const {G, playerID} = this.props;
+    return G.players[playerID].letters.map((letter, index) => <LjCard isActive={index === G.players[playerID].activeLetterIndex}>{letter}</LjCard>);
+  }
+
+  render() {
+    const {ctx, G, moves: {clickCard}, playerID} = this.props;
+
+    // Show only the current player's board view
+    if (playerID !== ctx.currentPlayer) {
+      return <></>;
+    }
 
     let tbody = [];
     for (let i = 0; i < 3; i++) {
@@ -46,14 +78,19 @@ export class TicTacToeBoard extends React.Component {
         {ctx.gameover && <div id="winner">{this.gameOverText}</div>}
       </div>
       <div>
-        <LjCard>A</LjCard>
-        <LjCard>B</LjCard>
-        <LjCard>C</LjCard>
-        <LjCard />
-        <LjCard>1</LjCard>
-        <LjCard>2</LjCard>
-        <LjCard>3</LjCard>
-        <LjCard>asdfasfjsal</LjCard>
+        <div>Visible cards</div>
+        {this.visibleCards.map((letter) => <LjCard>{letter}</LjCard>)}
+      </div>
+      <div>
+        <Button
+          id="btn1"
+          theme="primary"
+          themeType="contained"
+          onClick={this.handleNextLetter}
+          disabled={this.isNextLetterDisabled}
+        >
+          Next Letter
+        </Button>
       </div>
     </>;
   }

--- a/src/Game.js
+++ b/src/Game.js
@@ -1,7 +1,35 @@
 import { INVALID_MOVE } from 'boardgame.io/core';
 
 export const TicTacToe = {
-  setup: () => ({ cells: Array(9).fill(null) }),
+  setup: (ctx, setupData) => {
+    return {
+      cells: Array(9).fill(null),
+      players: {
+        0: {
+          activeLetterIndex: 0,
+          letters: ['A', 'S', 'D', 'F']
+        },
+        1: {
+          activeLetterIndex: 0,
+          letters: ['Q', 'W', 'E', 'R', 'T', 'Y']
+        }
+      },
+      // Build the deck here. No need for separate drawPile decks as long as we maintain the number of cards in each drawPile.
+      deck: [],
+      drawPiles: [
+        {
+          currentLetter: 'X',
+          cardsLeft: 8,
+        },{
+          currentLetter: 'Y',
+          cardsLeft: 8,
+        },{
+          currentLetter: 'Z',
+          cardsLeft: 8,
+        }
+      ]
+    };
+  },
 
   turn: {
     moveLimit: 1,
@@ -14,6 +42,25 @@ export const TicTacToe = {
       }
       G.cells[id] = ctx.currentPlayer;
     },
+    // Stubbed handler to process card clicks
+    clickCard: {
+      move: (G, ctx, id) => {
+        console.log('clickCard()');
+      },
+      noLimit: true,
+    },
+    // Handler for moving on to the next letter
+    nextLetter: {
+      move: (G, ctx, playerID) => {
+        G.players[playerID].activeLetterIndex++;
+      },
+      noLimit: true,
+    }
+  },
+
+  // TODO -- return sanitized game state for the active player
+  playerView: (G, ctx, playerID) => {
+    return G;
   },
 
   endIf: (G, ctx) => {

--- a/src/LjCard.js
+++ b/src/LjCard.js
@@ -6,9 +6,15 @@ import {
 
 export default class LjCard extends React.Component {
     render() {
-        return <Card>
+        const {children, isActive, onClick} = this.props;
+
+        return <Card onClick={onClick} style={{cursor: 'pointer'}}>
             <CardContent>
-                {this.props.children}
+                {
+                    isActive
+                        ? <span style={{fontWeight: '700'}}>{children}</span>
+                        : children
+                }
             </CardContent>
         </Card>
     }


### PR DESCRIPTION
Implemented "hot-seat" local multiplayer
Initialized players 0 and 1 with letters "ASDF" and "QWERTY"
Initialized 3 draw piles with letters "X", "Y", and "Z"
Tailored view specific to active player, that shows draw pile cards and other players' active cards.
Added a button for the active player to move on to the next letter.
Stubbed a handler for card clicks.